### PR TITLE
fix indendtation for deployment.yml

### DIFF
--- a/kubernetes.org
+++ b/kubernetes.org
@@ -561,21 +561,21 @@ metadata: # as the name implies, some info about deployment object
   name: nginx-deployment
   labels:
     app: nginx
-  spec: # desired state of the deployment
-    replicas: 3
-    selector:
-      matchLabels:
+spec: # desired state of the deployment
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
         app: nginx
-    template:
-      metadata:
-        labels:
-          app: nginx
-      spec: # desired state of the Pod
-        containers:
-          - name: nginx
-            image: nginx:1.7.9
-            ports:
-              - containerPort: 80
+    spec: # desired state of the Pod
+      containers:
+        - name: nginx
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 80
 #+end_src
 
 Once this is created, Kubernetes attaches the ~status~ field to the object


### PR DESCRIPTION
The indentation of spec in example deployment object was wrong.