### PR TITLE
1 byte (8 bits) max val = 255, not 256

### DIFF
--- a/k&r_c.org
+++ b/k&r_c.org
@@ -288,7 +288,7 @@ we also have signed or unsigned ints
 signed means the varialbe has sign, can be negative
 unsigned means only 0 and positive
 
-so, in 1 byte, unsigned can be 0 t0 256
+so, in 1 byte, unsigned can be 0 to 255
 and signed can be -128 - 127
 
 the header files limits.h and float.h contain symbolic constants for all these sizes


### PR DESCRIPTION
Maximum value of 1 byte is 1111 1111 which translates to 255 in decimal. 256 would be 1 0000 0000 which wouldn't fit inside 1 byte as it would need 9 bits.